### PR TITLE
Call create_user with all mapped user properties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,9 @@ Explanation
 
 **NEW_USER_PROFILE** Default settings for newly created users
 
-**ATTRIBUTES_MAP** Mapping of Django user attributes to SAML2 user attributes
+**ATTRIBUTES_MAP** Mapping of Django user attributes to SAML2 user attributes.
+This can also be a function to map SAML2 user identity attributes to Django
+user model attributes.
 
 **TRIGGER** Hooks to trigger additional actions during user login and creation
 flows. These TRIGGER hooks are strings containing a `dotted module name <https://docs.python.org/3/tutorial/modules.html#packages>`_

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -151,7 +151,11 @@ def denied(r):
 
 
 def map_user_props(user_identity):
-    return default_map_user_props(attributes_map, user_identity)
+    attributes_map = settings.SAML2_AUTH.get("ATTRIBUTES_MAP", {})
+    if hasattr(attributes_map, "__call__"):
+        return attributes_map(user_identity)
+    else:
+        return default_map_user_props(attributes_map, user_identity)
 
 
 def default_map_user_props(attributes_map, user_identity):


### PR DESCRIPTION
Fix the case where user cannot be created with just the username, due to
uniqueness constraints on other fields.

This also adds support for making `ATTRIBUTES_MAP` callable,
to support mapping user attributes dynamically. For example, you could
create usernames based on email address, by stripping everything after
the "@" symbol.